### PR TITLE
Add check for config in treeForVendor

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,6 +93,10 @@ module.exports = {
       trees.push(vendorTree);
     }
 
+    if(!this.bootstrapDatepickerOptions) {
+      this.bootstrapDatepickerOptions = this.getConfig();
+    }
+
     var bootstrapDatepickerPath = this.bootstrapDatepickerOptions.path;
     var datePickerJsTree =  new Funnel(bootstrapDatepickerPath, {
       destDir: 'bootstrap-datepicker',


### PR DESCRIPTION
Fix for ember-cli on 3.1.4 calling treeForVendor twice, but not the config.